### PR TITLE
Implement text search in catalog

### DIFF
--- a/src/app/Catalogo/page.jsx
+++ b/src/app/Catalogo/page.jsx
@@ -4,6 +4,7 @@
 
 import ProductList from "../components/ProductList";
 import FilterSidebar from "../components/FilterSidebar";
+import SearchBar from "../components/SearchBar";
 import { useSearchParams } from "next/navigation";
 import CartSidebar from "../components/CartSidebar";
 
@@ -17,6 +18,7 @@ export default function CatalogoPage() {
     stock:           sp.get("stock") ? Number(sp.get("stock")) : undefined,
     proveedorNombre: sp.getAll("proveedorNombre"),
     division:        sp.getAll("division"),
+    descripcion:     sp.get("descripcion") || undefined,
     kilosUnitarios: sp.getAll("kilosUnitarios").length > 0 ? sp.getAll("kilosUnitarios") : undefined, // Verifica si está vacío}
     linea:           sp.getAll("linea").length > 0 ? sp.getAll("linea") : undefined, // Verifica si está vacío
     fabrica:         sp.getAll("fabrica").length > 0 ? sp.getAll("fabrica") : undefined,// Verifica si está vacío
@@ -26,6 +28,9 @@ export default function CatalogoPage() {
     <div className="container mx-auto mt-5 pb-10">
       <CartSidebar />
       <h1 className="text-2xl font-bold mb-4">Catálogo de Productos</h1>
+      <div className="mb-4">
+        <SearchBar />
+      </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-2">
         <aside className="space-y-6 relative top-20">

--- a/src/app/api/products/route.js
+++ b/src/app/api/products/route.js
@@ -9,6 +9,7 @@ export async function GET(request) {
   const lineaArr   = url.searchParams.getAll('linea');
   const fabricaArr = url.searchParams.getAll('fabrica');
   const rubrosArr  = url.searchParams.getAll('rubroDescripcion');
+  const descripcion = url.searchParams.get('descripcion');
 
   // 2) Construye filters convirtiendo arrays vacíos en undefined
   const filters = {
@@ -17,6 +18,7 @@ export async function GET(request) {
     minPrice:        url.searchParams.has('minPrice')  ? Number(url.searchParams.get('minPrice')) : undefined,
     maxPrice:        url.searchParams.has('maxPrice')  ? Number(url.searchParams.get('maxPrice')) : undefined,
     division:        url.searchParams.get('division')   || undefined,
+    descripcion:     descripcion || undefined,
 
     kilosUnitarios:  kilosArr.length   > 0 ? kilosArr   : undefined,
     linea:           lineaArr.length   > 0 ? lineaArr   : undefined,

--- a/src/app/components/ProductList.jsx
+++ b/src/app/components/ProductList.jsx
@@ -39,6 +39,9 @@ export default function ProductsList({ filters }) {
       params.append(key, String(value));
     }
   });
+  if (filters.descripcion) {
+    params.set("descripcion", filters.descripcion);
+  }
   const qs = params.toString();
   const { data, error } = useSWR(`/api/products?${qs}`, fetcher);
 

--- a/src/app/components/SearchBar.jsx
+++ b/src/app/components/SearchBar.jsx
@@ -1,0 +1,35 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect } from "react";
+
+export default function SearchBar() {
+  const router = useRouter();
+  const sp = useSearchParams();
+  const [value, setValue] = useState(sp.get("descripcion") || "");
+
+  useEffect(() => {
+    setValue(sp.get("descripcion") || "");
+  }, [sp]);
+
+  function handleChange(e) {
+    const val = e.target.value;
+    setValue(val);
+    const params = new URLSearchParams(Array.from(sp.entries()));
+    if (val) {
+      params.set("descripcion", val);
+    } else {
+      params.delete("descripcion");
+    }
+    router.push(`/Catalogo?${params.toString()}`);
+  }
+
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={handleChange}
+      placeholder="Buscar productos..."
+      className="w-full p-2 border rounded-md"
+    />
+  );
+}

--- a/src/app/services/productService.js
+++ b/src/app/services/productService.js
@@ -23,6 +23,11 @@ export const ProductService = {
       params.push(filters.stock);
     }
 
+    if (filters.descripcion) {
+      clauses.push("descripcion LIKE ?");
+      params.push(`%${filters.descripcion}%`);
+    }
+
     // proveedorNombre puede ser string o array
     if (filters.proveedorNombre) {
       const arr = Array.isArray(filters.proveedorNombre)


### PR DESCRIPTION
## Summary
- add a `SearchBar` component with controlled input that updates URL query
- include search bar on catalog page and pass `descripcion` filter
- send `descripcion` in ProductList requests
- accept `descripcion` in products API route
- filter by description in ProductService

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842e3b549b08321a529d9f8a3d39148